### PR TITLE
Feature/#60 - Implementar paginação nas APIs que retornam todos os registros de determinado recurso

### DIFF
--- a/src/main/java/br/com/fiap/fastfood/api/adapters/driven/infrastructure/repository/adapter/CategoryRepositoryAdapterImpl.java
+++ b/src/main/java/br/com/fiap/fastfood/api/adapters/driven/infrastructure/repository/adapter/CategoryRepositoryAdapterImpl.java
@@ -3,13 +3,17 @@ package br.com.fiap.fastfood.api.adapters.driven.infrastructure.repository.adapt
 import br.com.fiap.fastfood.api.adapters.driven.infrastructure.entity.category.CategoryEntity;
 import br.com.fiap.fastfood.api.adapters.driven.infrastructure.mapper.CategoryMapper;
 import br.com.fiap.fastfood.api.adapters.driven.infrastructure.repository.category.CategoryRepository;
-import br.com.fiap.fastfood.api.core.domain.model.category.Category;
 import br.com.fiap.fastfood.api.core.application.ports.repository.CategoryRepositoryPort;
+import br.com.fiap.fastfood.api.core.domain.model.category.Category;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Component;
 
 import java.util.List;
 import java.util.Optional;
+import java.util.stream.Collectors;
 
 @Component
 public class CategoryRepositoryAdapterImpl implements CategoryRepositoryPort {
@@ -65,8 +69,11 @@ public class CategoryRepositoryAdapterImpl implements CategoryRepositoryPort {
   }
 
   @Override
-  public List<Category> getAll() {
-    List<CategoryEntity> entityCategories = repository.findAll();
-    return entityCategories.stream().map(mapper::toDomain).toList();
+  public Page<Category> getAll(Pageable pageable) {
+    Page<CategoryEntity> entityCategories = repository.findAll(pageable);
+    List<Category> domainCategories = entityCategories.stream()
+            .map(mapper::toDomain)
+            .collect(Collectors.toList());
+    return new PageImpl<>(domainCategories, pageable, entityCategories.getTotalElements());
   }
 }

--- a/src/main/java/br/com/fiap/fastfood/api/adapters/driven/infrastructure/repository/adapter/MenuProductRepositoryAdapterImpl.java
+++ b/src/main/java/br/com/fiap/fastfood/api/adapters/driven/infrastructure/repository/adapter/MenuProductRepositoryAdapterImpl.java
@@ -8,6 +8,9 @@ import br.com.fiap.fastfood.api.core.application.ports.repository.MenuProductRep
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Component;
 
 import java.util.List;
@@ -50,9 +53,14 @@ public class MenuProductRepositoryAdapterImpl implements MenuProductRepositoryPo
   }
 
   @Override
-  public List<MenuProduct> getAll() {
-    List<MenuProductEntity> entityProducts = repository.findAll();
-    return entityProducts.stream().map(mapper::toDomain).toList();
+  public Page<MenuProduct> getAll(Pageable pageable) {
+    Page<MenuProductEntity> entityProducts = repository.findAll(pageable);
+
+    List<MenuProduct> domainMenuProducts = entityProducts.stream()
+            .map(mapper::toDomain)
+            .collect(Collectors.toList());
+
+    return new PageImpl<>(domainMenuProducts, pageable, entityProducts.getTotalElements());
   }
 
   @Override

--- a/src/main/java/br/com/fiap/fastfood/api/adapters/driver/controller/CategoryController.java
+++ b/src/main/java/br/com/fiap/fastfood/api/adapters/driver/controller/CategoryController.java
@@ -2,23 +2,18 @@ package br.com.fiap.fastfood.api.adapters.driver.controller;
 
 import br.com.fiap.fastfood.api.adapters.driven.infrastructure.mapper.CategoryMapper;
 import br.com.fiap.fastfood.api.adapters.driver.dto.category.CategoryDTO;
-import br.com.fiap.fastfood.api.adapters.driver.dto.category.CategoryResponseDTO;
 import br.com.fiap.fastfood.api.core.application.service.CategoryServicePortImpl;
 import br.com.fiap.fastfood.api.core.domain.model.category.Category;
 import br.com.fiap.fastfood.api.core.domain.ports.inbound.CategoryServicePort;
 import jakarta.validation.Valid;
-import java.util.List;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.DeleteMapping;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.PutMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequestMapping("/categories")
@@ -35,11 +30,16 @@ public class CategoryController {
   }
 
   @GetMapping
-  public ResponseEntity<CategoryResponseDTO> getAll() {
-    List<Category> allCategories = categoryServicePort.getAll();
-    List<CategoryDTO> listCategoryDTO = mapper.toCategoryDTO(allCategories);
-    CategoryResponseDTO response = new CategoryResponseDTO(listCategoryDTO);
-    return ResponseEntity.status(HttpStatus.CREATED).body(response);
+  public ResponseEntity<Page<CategoryDTO>> getAll(
+          @RequestParam(value = "page", defaultValue = "0") int page,
+          @RequestParam(value = "size", defaultValue = "10") int size,
+          @RequestParam(value = "sort", defaultValue = "id") String sort,
+          @RequestParam(value = "direction", defaultValue = "asc") String direction) {
+    Sort.Direction sortDirection = Sort.Direction.fromString(direction);
+    Pageable pageable = PageRequest.of(page, size, Sort.by(sortDirection, sort));
+    Page<Category> categoryPage = categoryServicePort.getAll(pageable);
+    Page<CategoryDTO> categoryDTOPage = categoryPage.map(mapper::toCategoryDTO);
+    return ResponseEntity.ok(categoryDTOPage);
   }
 
   @GetMapping("/{identifier}")

--- a/src/main/java/br/com/fiap/fastfood/api/adapters/driver/controller/MenuProductController.java
+++ b/src/main/java/br/com/fiap/fastfood/api/adapters/driver/controller/MenuProductController.java
@@ -2,23 +2,18 @@ package br.com.fiap.fastfood.api.adapters.driver.controller;
 
 import br.com.fiap.fastfood.api.adapters.driven.infrastructure.mapper.MenuProductMapper;
 import br.com.fiap.fastfood.api.adapters.driver.dto.product.MenuProductDTO;
-import br.com.fiap.fastfood.api.adapters.driver.dto.product.MenuProductResponseDTO;
 import br.com.fiap.fastfood.api.core.application.service.MenuProductServicePortImpl;
 import br.com.fiap.fastfood.api.core.domain.model.product.MenuProduct;
 import br.com.fiap.fastfood.api.core.domain.ports.inbound.MenuProductServicePort;
 import jakarta.validation.Valid;
-import java.util.List;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.DeleteMapping;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.PutMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequestMapping("/menu-products")
@@ -35,11 +30,17 @@ public class MenuProductController {
   }
 
   @GetMapping
-  public ResponseEntity<MenuProductResponseDTO> getAll() {
-    List<MenuProduct> allProducts = menuProductServicePort.getAll();
-    List<MenuProductDTO> listMenuProductDTO = mapper.toMenuProductDTO(allProducts);
-    MenuProductResponseDTO response = new MenuProductResponseDTO(listMenuProductDTO);
-    return ResponseEntity.status(HttpStatus.CREATED).body(response);
+  public ResponseEntity<Page<MenuProductDTO>> getAll(
+          @RequestParam(value = "page", defaultValue = "0") int page,
+          @RequestParam(value = "size", defaultValue = "10") int size,
+          @RequestParam(value = "sort", defaultValue = "id") String sort,
+          @RequestParam(value = "direction", defaultValue = "asc") String direction) {
+    Sort.Direction sortDirection = Sort.Direction.fromString(direction);
+    Pageable pageable = PageRequest.of(page, size, Sort.by(sortDirection, sort));
+
+    Page<MenuProduct> allProducts = menuProductServicePort.getAll(pageable);
+    Page<MenuProductDTO> listMenuProductDTO = allProducts.map(mapper::toMenuProductDTO);
+    return ResponseEntity.ok(listMenuProductDTO);
   }
 
   @GetMapping("/{id}")

--- a/src/main/java/br/com/fiap/fastfood/api/core/application/ports/repository/CategoryRepositoryPort.java
+++ b/src/main/java/br/com/fiap/fastfood/api/core/application/ports/repository/CategoryRepositoryPort.java
@@ -2,13 +2,15 @@ package br.com.fiap.fastfood.api.core.application.ports.repository;
 
 import br.com.fiap.fastfood.api.core.domain.model.category.Category;
 import br.com.fiap.fastfood.api.core.application.ports.BaseRepository;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 
 import java.util.List;
 import java.util.Optional;
 
 public interface CategoryRepositoryPort extends BaseRepository<Category, Long> {
 
-    List<Category> getAll();
+    Page<Category> getAll(Pageable pageable);
 
     Optional<Category> findByName(String name);
 

--- a/src/main/java/br/com/fiap/fastfood/api/core/application/ports/repository/MenuProductRepositoryPort.java
+++ b/src/main/java/br/com/fiap/fastfood/api/core/application/ports/repository/MenuProductRepositoryPort.java
@@ -2,12 +2,14 @@ package br.com.fiap.fastfood.api.core.application.ports.repository;
 
 import br.com.fiap.fastfood.api.core.application.ports.BaseRepository;
 import br.com.fiap.fastfood.api.core.domain.model.product.MenuProduct;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 
 import java.util.List;
 
 public interface MenuProductRepositoryPort extends BaseRepository<MenuProduct, Long> {
 
-    List<MenuProduct> getAll();
+    Page<MenuProduct> getAll(Pageable pageable);
     void update(MenuProduct menuProduct);
     List<Long> fetchProductsRelatedToProduct(Long productId);
     List<MenuProduct> findAllById(List<Long> ids);

--- a/src/main/java/br/com/fiap/fastfood/api/core/application/service/CategoryServicePortImpl.java
+++ b/src/main/java/br/com/fiap/fastfood/api/core/application/service/CategoryServicePortImpl.java
@@ -11,6 +11,8 @@ import br.com.fiap.fastfood.api.core.domain.ports.inbound.MenuProductServicePort
 import java.util.List;
 import java.util.Optional;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 
 @Service
@@ -29,8 +31,8 @@ public class CategoryServicePortImpl implements CategoryServicePort {
   }
 
   @Override
-  public List<Category> getAll() {
-    return repository.getAll();
+  public Page<Category> getAll(Pageable pageable) {
+    return repository.getAll(pageable);
   }
 
   @Override

--- a/src/main/java/br/com/fiap/fastfood/api/core/application/service/MenuProductServicePortImpl.java
+++ b/src/main/java/br/com/fiap/fastfood/api/core/application/service/MenuProductServicePortImpl.java
@@ -10,6 +10,8 @@ import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.util.CollectionUtils;
 
@@ -28,8 +30,8 @@ public class MenuProductServicePortImpl implements MenuProductServicePort {
   }
 
   @Override
-  public List<MenuProduct> getAll() {
-    return repository.getAll();
+  public Page<MenuProduct> getAll(Pageable pageable) {
+    return repository.getAll(pageable);
   }
 
   @Override

--- a/src/main/java/br/com/fiap/fastfood/api/core/domain/ports/inbound/CategoryServicePort.java
+++ b/src/main/java/br/com/fiap/fastfood/api/core/domain/ports/inbound/CategoryServicePort.java
@@ -1,11 +1,12 @@
 package br.com.fiap.fastfood.api.core.domain.ports.inbound;
 
 import br.com.fiap.fastfood.api.core.domain.model.category.Category;
-import java.util.List;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 
 public interface CategoryServicePort {
 
-  List<Category> getAll();
+  Page<Category> getAll(Pageable pageable);
   Category getById(Long id);
   Category getByName(String name);
   void create(Category category);

--- a/src/main/java/br/com/fiap/fastfood/api/core/domain/ports/inbound/MenuProductServicePort.java
+++ b/src/main/java/br/com/fiap/fastfood/api/core/domain/ports/inbound/MenuProductServicePort.java
@@ -1,11 +1,14 @@
 package br.com.fiap.fastfood.api.core.domain.ports.inbound;
 
 import br.com.fiap.fastfood.api.core.domain.model.product.MenuProduct;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+
 import java.util.List;
 
 public interface MenuProductServicePort {
 
-  List<MenuProduct> getAll();
+  Page<MenuProduct> getAll(Pageable pageable);
   MenuProduct getById(Long id);
   void register(MenuProduct menuProduct);
   void remove(Long id);


### PR DESCRIPTION
## Tarefa
[#60 - Implementar paginação nas APIs que retornam todos os registros de determinado recurso](https://trello.com/c/6vqXrl2h/60-60-implementar-pagina%C3%A7%C3%A3o-nas-apis-que-retornam-todos-os-registros-de-determinado-recurso)

## Descrição

Principais alterações: 

- [NEW] API listAll MenuProduct com paginação
- [NEW] API listAll Categorias com paginação

## Débito Técnico
> Escrever testes.

## cURL && Evidência
![imagem 1](https://github.com/user-attachments/assets/975bc52e-25c7-4750-adda-95c598089ce6)
![imagem 2](https://github.com/user-attachments/assets/dadb7cd8-2f9b-4172-acd9-8e9cd74f2472)
