### PR TITLE
66 - Enhancement - Nao remove mais produto do cardapio (apenas desativa)

### DIFF
--- a/init.sql
+++ b/init.sql
@@ -127,6 +127,7 @@ CREATE TABLE public.menu_product (
                                      updated_at timestamp(6) NULL,
                                      description varchar(255) NULL,
                                      "name" varchar(255) NULL,
+                                     active bool NULL,
                                      CONSTRAINT menu_product_pkey PRIMARY KEY (id)
 );
 
@@ -177,6 +178,7 @@ CREATE TABLE public.campaign_product (
                                          updated_at timestamp(6) NULL,
                                          description varchar(255) NULL,
                                          "name" varchar(255) NULL,
+                                         active bool NULL,
                                          CONSTRAINT campaign_product_pkey PRIMARY KEY (id),
                                          CONSTRAINT fkmxbi858du9wywnrtpon2lfmbm FOREIGN KEY (campaign_id) REFERENCES public.campaign(id)
 );
@@ -308,22 +310,22 @@ CREATE TABLE public.order_product_optional (
                                                CONSTRAINT fkmvtwrsxapsas4s1u5la69l93x FOREIGN KEY (order_optional_id) REFERENCES public.order_product(id)
 );
 
-INSERT INTO public.menu_product ("cost",ingredient,optional,price,quantity,created_at,id,preparation_time,updated_at,description,"name") VALUES
-                                                                                                                                             (0.80,true,true,1.00,1,'2024-08-12 20:00:51.497',1,60000,NULL,NULL,'Hamburguer'),
-                                                                                                                                             (0.30,true,true,0.50,1,'2024-08-12 20:01:08.070',2,NULL,NULL,NULL,'Mustard'),
-                                                                                                                                             (0.05,true,true,0.50,1,'2024-08-12 20:01:19.647',3,NULL,NULL,NULL,'Ketchup'),
-                                                                                                                                             (0.50,true,true,0.80,1,'2024-08-12 20:01:33.020',4,NULL,NULL,NULL,'Bread'),
-                                                                                                                                             (1.65,false,false,15.50,1,'2024-08-12 20:01:35.983',5,150000,NULL,NULL,'Hyper Burger'),
-                                                                                                                                             (0.50,true,false,2.50,1,'2024-08-12 20:06:20.570',6,0,NULL,NULL,'Água'),
-                                                                                                                                             (0.15,true,true,1.00,1,'2024-08-12 20:07:46.816',7,30000,NULL,NULL,'Limão'),
-                                                                                                                                             (0.90,true,true,1.50,1,'2024-08-12 20:08:15.114',8,60000,NULL,NULL,'Morango'),
-                                                                                                                                             (0.90,true,true,1.50,1,'2024-08-12 20:08:39.972',9,60000,NULL,NULL,'Amora'),
-                                                                                                                                             (2.45,false,false,13.00,1,'2024-08-12 20:10:13.518',10,180000,NULL,NULL,'Pink Lemonade');
-INSERT INTO public.menu_product ("cost",ingredient,optional,price,quantity,created_at,id,preparation_time,updated_at,description,"name") VALUES
-                                                                                                                                             (2.00,true,false,4.00,1,'2024-08-12 22:14:11.589',11,240000,NULL,NULL,'Batata'),
-                                                                                                                                             (2.50,true,false,10.00,1,'2024-08-12 22:15:26.349',12,180000,NULL,'Batata e oleo!','Batata Frita'),
-                                                                                                                                             (2.50,true,false,8.00,1,'2024-08-12 22:17:55.462',13,0,NULL,'Glace, glace e mais glace!','Bolinho de pote'),
-                                                                                                                                             (2.50,false,false,20.00,1,'2024-08-12 22:18:54.881',14,120000,NULL,'Glace, glace e mais glace (com sorvete incluso)!','Petit Gateou');
+INSERT INTO public.menu_product ("cost",ingredient,optional,price,quantity,created_at,id,preparation_time,updated_at,description,"name", "active") VALUES
+                                                                                                                                             (0.80,true,true,1.00,1,'2024-08-12 20:00:51.497',1,60000,NULL,NULL,'Hamburguer', true),
+                                                                                                                                             (0.30,true,true,0.50,1,'2024-08-12 20:01:08.070',2,NULL,NULL,NULL,'Mustard', true),
+                                                                                                                                             (0.05,true,true,0.50,1,'2024-08-12 20:01:19.647',3,NULL,NULL,NULL,'Ketchup', true),
+                                                                                                                                             (0.50,true,true,0.80,1,'2024-08-12 20:01:33.020',4,NULL,NULL,NULL,'Bread', true),
+                                                                                                                                             (1.65,false,false,15.50,1,'2024-08-12 20:01:35.983',5,150000,NULL,NULL,'Hyper Burger', true),
+                                                                                                                                             (0.50,true,false,2.50,1,'2024-08-12 20:06:20.570',6,0,NULL,NULL,'Água', true),
+                                                                                                                                             (0.15,true,true,1.00,1,'2024-08-12 20:07:46.816',7,30000,NULL,NULL,'Limão', true),
+                                                                                                                                             (0.90,true,true,1.50,1,'2024-08-12 20:08:15.114',8,60000,NULL,NULL,'Morango', true),
+                                                                                                                                             (0.90,true,true,1.50,1,'2024-08-12 20:08:39.972',9,60000,NULL,NULL,'Amora', true),
+                                                                                                                                             (2.45,false,false,13.00,1,'2024-08-12 20:10:13.518',10,180000,NULL,NULL,'Pink Lemonade', true);
+INSERT INTO public.menu_product ("cost",ingredient,optional,price,quantity,created_at,id,preparation_time,updated_at,description,"name", "active") VALUES
+                                                                                                                                             (2.00,true,false,4.00,1,'2024-08-12 22:14:11.589',11,240000,NULL,NULL,'Batata', true),
+                                                                                                                                             (2.50,true,false,10.00,1,'2024-08-12 22:15:26.349',12,180000,NULL,'Batata e oleo!','Batata Frita', true),
+                                                                                                                                             (2.50,true,false,8.00,1,'2024-08-12 22:17:55.462',13,0,NULL,'Glace, glace e mais glace!','Bolinho de pote', true),
+                                                                                                                                             (2.50,false,false,20.00,1,'2024-08-12 22:18:54.881',14,120000,NULL,'Glace, glace e mais glace (com sorvete incluso)!','Petit Gateou', true);
 
 
 

--- a/src/main/java/br/com/fiap/fastfood/api/adapters/driven/infrastructure/entity/product/MenuProductEntity.java
+++ b/src/main/java/br/com/fiap/fastfood/api/adapters/driven/infrastructure/entity/product/MenuProductEntity.java
@@ -20,4 +20,7 @@ public class MenuProductEntity extends ProductEntity {
     )
     protected List<MenuProductEntity> ingredients;
 
+    @Column(name = "active")
+    protected boolean active;
+
 }

--- a/src/main/java/br/com/fiap/fastfood/api/adapters/driven/infrastructure/repository/adapter/MenuProductRepositoryAdapterImpl.java
+++ b/src/main/java/br/com/fiap/fastfood/api/adapters/driven/infrastructure/repository/adapter/MenuProductRepositoryAdapterImpl.java
@@ -26,7 +26,7 @@ public class MenuProductRepositoryAdapterImpl implements MenuProductRepositoryPo
 
   @Override
   public Optional<MenuProductDTO> findById(Long identifier) {
-    Optional<MenuProductEntity> menuProductEntityOpt = repository.findById(identifier);
+    Optional<MenuProductEntity> menuProductEntityOpt = repository.findByIdAndActiveIsTrue(identifier);
     return menuProductEntityOpt.map(mapper::toDTO);
   }
 
@@ -43,7 +43,7 @@ public class MenuProductRepositoryAdapterImpl implements MenuProductRepositoryPo
     if (menuProductEntityOpt.isEmpty()) {
       return false;
     }
-    repository.deleteById(identifier);
+    repository.updateActive(identifier, false);
     return true;
   }
 

--- a/src/main/java/br/com/fiap/fastfood/api/adapters/driven/infrastructure/repository/product/MenuProductRepository.java
+++ b/src/main/java/br/com/fiap/fastfood/api/adapters/driven/infrastructure/repository/product/MenuProductRepository.java
@@ -2,15 +2,25 @@ package br.com.fiap.fastfood.api.adapters.driven.infrastructure.repository.produ
 
 import br.com.fiap.fastfood.api.adapters.driven.infrastructure.entity.product.MenuProductEntity;
 import java.util.List;
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
+import org.springframework.transaction.annotation.Transactional;
 
 @Repository
 public interface MenuProductRepository extends JpaRepository<MenuProductEntity, Long> {
 
   @Query(value = "SELECT DISTINCT(product_id) FROM menu_product_ingredient WHERE ingredient_id = :ingredientId", nativeQuery = true)
   List<Long> fetchProductsByIngredient(@Param("ingredientId") Long ingredientId);
+
+  Optional<MenuProductEntity> findByIdAndActiveIsTrue(Long id);
+
+  @Modifying
+  @Transactional
+  @Query(value = "UPDATE MenuProductEntity mpe SET mpe.active = :active WHERE mpe.id = :id")
+  void updateActive(@Param("id") Long id, @Param("active") boolean active);
 
 }

--- a/src/main/java/br/com/fiap/fastfood/api/core/application/dto/product/MenuProductDTO.java
+++ b/src/main/java/br/com/fiap/fastfood/api/core/application/dto/product/MenuProductDTO.java
@@ -11,15 +11,16 @@ import java.util.List;
 @Builder(access = AccessLevel.PUBLIC)
 public class MenuProductDTO {
 
-    private Long id;
-    private String name;
-    private String description;
-    private BigDecimal price;
-    private Long preparationTimeInMillis;
-    private int quantity;
-    private BigDecimal cost;
-    private List<MenuProductDTO> ingredients;
-    private boolean optional;
-    private boolean ingredient;
+    protected Long id;
+    protected String name;
+    protected String description;
+    protected BigDecimal price;
+    protected Long preparationTimeInMillis;
+    protected int quantity;
+    protected BigDecimal cost;
+    protected List<MenuProductDTO> ingredients;
+    protected boolean optional;
+    protected boolean ingredient;
+    protected boolean active;
 
 }

--- a/src/main/java/br/com/fiap/fastfood/api/core/application/service/MenuProductServicePortImpl.java
+++ b/src/main/java/br/com/fiap/fastfood/api/core/application/service/MenuProductServicePortImpl.java
@@ -56,6 +56,7 @@ public class MenuProductServicePortImpl implements MenuProductServicePort {
   public void remove(Long id) {
     MenuProductDTO target = this.getById(id);
     List<Long> productsThatUseTarget = repository.fetchProductsRelatedToProduct(target.getId());
+    // TODO: deixar cancelar apenas se não for o unico produto ativo de algum outro produto. Criado em: 13/08/2024 ás 12:43:51.
     boolean removed = repository.delete(target.getId());
 
     // After remove target product, we need to check if other product used it as optional or ingredient.

--- a/src/main/java/br/com/fiap/fastfood/api/core/domain/model/product/MenuProduct.java
+++ b/src/main/java/br/com/fiap/fastfood/api/core/domain/model/product/MenuProduct.java
@@ -27,6 +27,7 @@ import org.springframework.util.CollectionUtils;
 public class MenuProduct extends Product {
 
     protected List<MenuProduct> ingredients;
+    protected boolean active;
 
     @Override
     public BigDecimal getCost() {

--- a/src/main/java/br/com/fiap/fastfood/api/core/domain/model/product/OrderProduct.java
+++ b/src/main/java/br/com/fiap/fastfood/api/core/domain/model/product/OrderProduct.java
@@ -40,12 +40,13 @@ public class OrderProduct extends Product {
         BigDecimal optionalsCost = CollectionUtils.isEmpty(optionals) ? BigDecimal.ZERO :
             optionals.stream()
                 .filter(op -> Objects.nonNull(op) && Objects.nonNull(op.getCost()))
-                .map(op -> op.getCost().multiply(BigDecimal.valueOf(op.getQuantity())))
+                .map(Product::getCost)
                 .reduce(BigDecimal.ZERO, BigDecimal::add);
         if (quantity == 0) {
             quantity = 1;
         }
-        this.cost = ingredientCost.add(optionalsCost).multiply(BigDecimal.valueOf(quantity));
+        BigDecimal productCost = ingredientCost.add(optionalsCost);
+        this.cost = productCost.multiply(BigDecimal.valueOf(quantity));
     }
 
     public void calculatePrice() {


### PR DESCRIPTION
## Tarefa
[#66 - Ajustar consulta de pedido ao remover produto de algum pedido](https://trello.com/c/7X6wXd9t/66-66-ajustar-consulta-de-pedido-ao-remover-produto-de-algum-pedido)

## Descrição

Principais alterações: 

- [FIX] Agora a consulta de pedidos nao quebra mais ao consultar um pedido que tenha um produto do menu desativado (antigamente excluia).

## Débito Técnico
> Precisa escrever testes.

## cURL && Evidência
![image](https://github.com/user-attachments/assets/81381f5f-21bc-43fb-ad73-e11852bb684b)

